### PR TITLE
Have coredns forward to internal GCP DNS (169.254.169.254)

### DIFF
--- a/modules/microk8s/main.tf
+++ b/modules/microk8s/main.tf
@@ -359,7 +359,7 @@ runcmd:
 - chmod 775 /usr/local/etc/anthos
 - chgrp -R ubuntu /usr/local/etc/anthos
 - microk8s status --wait-ready
-- microk8s enable dashboard dns storage
+- microk8s enable dashboard dns:169.254.169.254 storage
 - - gcloud
   - compute 
   - instances 


### PR DESCRIPTION
Have coredns forward to internal GCP DNS (169.254.169.254) instead of external Google DNS (8.8.8.8/8.8.4.4).

Required if pods are to use the machine service account.